### PR TITLE
Remove NOTAM & PIB section from landing page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -34,7 +34,6 @@ import {
   FaGlobe,
   FaMapMarkerAlt,
   FaFileAlt,
-  FaExclamationTriangle,
 } from "react-icons/fa";
 
 const PRODUCT_ICONS = {
@@ -189,12 +188,6 @@ function App() {
                             name: "Aeronautical Information Circulars",
                             desc: "Important notices and information for aviation community",
                             iconBg: "emerald",
-                          },
-                          {
-                            icon: FaExclamationTriangle,
-                            name: "NOTAM & PIB",
-                            desc: "Notices to Airmen and Pre-flight Information Bulletins",
-                            iconBg: "red",
                           },
                           {
                             icon: FaMap,


### PR DESCRIPTION
This update removes the “NOTAM & PIB” section from the landing page as it is not  required in the current system scope.